### PR TITLE
Remove node-inspector and debug-ide

### DIFF
--- a/bin/debug-ide
+++ b/bin/debug-ide
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
-
-../node_modules/.bin/node-inspector --hidden node_modules/ --hidden test/ --web-host $(/sbin/ifconfig eth0 | grep "inet addr" | awk -F: '{print $2}' | awk '{print $1}') --web-port $UID & ../node_modules/.bin/mocha --debug-brk --watch
-
-trap - SIGINT SIGTERM EXIT

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "expect": "^1.20.2",
     "jsdom": "^9.4.1",
     "mocha": "^2.5.3",
-    "mocha-multi": "^0.9.0",
-    "node-inspector": "^0.12.8"
+    "mocha-multi": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "Practice with loops, arrays, and functions in JavaScript on Learn",
   "main": "index.js",
   "scripts": {
-    "debug": "node-debug --hidden node_modules _mocha --watch",
-    "debug-ide": "./bin/debug-ide",
     "test": "mocha -R mocha-multi --reporter-options nyan=-,json=.results.json"
   },
   "repository": {


### PR DESCRIPTION
Per @gj, node-inspector is to be deprecated in FI
lessons.

After removing the dep, we also find that
`debug-idea` is wrapping calls to it. Therefore we
delete that as well.